### PR TITLE
INFRA-60: adding hostname to datadog metric on ip uploader

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ This setup will use SAML to connect to Atlassian. You need to add the following 
 This repository contains the following components that are used to run OpenMRS ID:
 
 1. Keycloak extension
-2. Postfix Docker configuration
-3. Keycloak Theme
+2. Keycloak Theme
+3. Postfix Docker configuration
+4. Atlassian IP updater for postfix
 
 ### Keycloak Extension
 
@@ -100,6 +101,14 @@ Choose "OpenMRS Mapper For NameID."
 The extension is built as a `jar` and will be copied to the Keycloak image during the Keycloak image build. Learn more
 about Keycloak extensions [here](a link).
 
+### Keycloak Theme
+
+This theme is to enhace the look and feel of the login and registration process.
+
+This is a custom theme for OpenMRS ID based on the [Keywind](https://github.com/lukin/keywind) theme for Keycloak. Learn
+more about Keycloak themes here: [Keycloak Themes](https://www.keycloak.org/docs/latest/server_development/#_themes).
+![Preview](docs/preview.jpeg)
+
 ### Postfix
 
 The user's email is saved by Atlassian as the virtual email address mentioned above. As a result, all notifications and
@@ -110,15 +119,11 @@ MTA) that routes and delivers email messages.
 Whenever Atlassian receives an email, postfix queries for a user in the LDAP where the username is the username part of
 the received email address. Then, it retrieves the email address of the returned user and forwards the received email.
 
+`IP udpater` script will check Atlassian, and update postfix configuration based on Atlassian's new IPs. In datadog, you can see metrics `atlassian.ip_updater.ip_count` and `atlassian.ip_updater.postfix_reload_success` related to it. HTTP endpoints `/postfix` and `/status` give a bit of insight about it as well
+
 ![Untitled](docs/Untitled.png)
 
-### Keycloak Theme
 
-This theme is to enhace the look and feel of the login and registration process.
-
-This is a custom theme for OpenMRS ID based on the [Keywind](https://github.com/lukin/keywind) theme for Keycloak. Learn
-more about Keycloak themes here: [Keycloak Themes](https://www.keycloak.org/docs/latest/server_development/#_themes).
-![Preview](docs/preview.jpeg)
 
 #### **Add a custom announcement**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
     build:
       context: postfix
       dockerfile: Dockerfile
+    volumes:
+      - ip_updater_logs:/var/logs/ip_updater/
     ports:
       - "225:25"
       - "8090:8090"  # Health check port
@@ -64,8 +66,11 @@ services:
       - ATLASSIAN_IP_JSON_URL=${ATLASSIAN_IP_JSON_URL:-https://ip-ranges.atlassian.com/}
       - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
       - IP_CHECK_INTERVAL=${IP_CHECK_INTERVAL:-3600}
+      - DATADOG_HOSTNAME=${HOST_HOSTNAME}
       # Health Check Service
       - HEALTH_PORT=${HEALTH_PORT:-8090}
 volumes:
   postgres_data:
+    driver: local
+  ip_updater_logs:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,9 +64,12 @@ services:
       - LDAP_PORT=${LDAP_PORT:-389}
       # IP Updater Configuration
       - ATLASSIAN_IP_JSON_URL=${ATLASSIAN_IP_JSON_URL:-https://ip-ranges.atlassian.com/}
-      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL}
+      - DATADOG_API_KEY=${DATADOG_API_KEY}
+      - DATADOG_APP_KEY=${DATADOG_APP_KEY}
+      - DATADOG_SITE=${DATADOG_SITE:-datadoghq.com}
+      - DATADOG_HOSTNAME=localhost.openmrs.org
       - IP_CHECK_INTERVAL=${IP_CHECK_INTERVAL:-3600}
-      - DATADOG_HOSTNAME=${HOST_HOSTNAME}
+      - METRIC_REPORT_INTERVAL=${METRIC_REPORT_INTERVAL:-300}
       # Health Check Service
       - HEALTH_PORT=${HEALTH_PORT:-8090}
 volumes:

--- a/postfix/ip_updater.py
+++ b/postfix/ip_updater.py
@@ -30,6 +30,8 @@ class AtlassianIPUpdater:
         self.datadog_api_key = os.getenv('DATADOG_API_KEY')
         self.datadog_app_key = os.getenv('DATADOG_APP_KEY')
         self.datadog_site = os.getenv('DATADOG_SITE', 'datadoghq.com')  # Default to US site
+        self.datadog_hostname = os.getenv('DATADOG_HOSTNAME', "unknown")
+
         self.check_interval = int(os.getenv('IP_CHECK_INTERVAL', '3600'))
         self.metric_interval = int(os.getenv('METRIC_REPORT_INTERVAL', '300'))  # 5 minutes default
         
@@ -65,7 +67,7 @@ class AtlassianIPUpdater:
             return
             
         if tags is None:
-            tags = ['service:postfix', 'component:ip-updater']
+            tags = ['service:postfix', 'component:ip-updater', f"host:{self.datadog_hostname}"]
         
         # DataDog Events API endpoint
         url = f"https://api.{self.datadog_site}/api/v1/events"
@@ -102,7 +104,7 @@ class AtlassianIPUpdater:
             return
             
         if tags is None:
-            tags = ['service:postfix', 'component:ip-updater']
+            tags = ['service:postfix', 'component:ip-updater', f"host:{self.datadog_hostname}"]
         
         # DataDog Metrics API endpoint
         url = f"https://api.{self.datadog_site}/api/v1/series"
@@ -128,7 +130,7 @@ class AtlassianIPUpdater:
         try:
             response = requests.post(url, json=payload, headers=headers, timeout=10)
             response.raise_for_status()
-            logger.debug(f"DataDog metric sent: {metric_name}={value}")
+            logger.debug(f"DataDog metric sent: {metric_name}={value}, tags: {tags}")
         except Exception as e:
             logger.error(f"Failed to send DataDog metric: {e}")
 

--- a/postfix/startup.sh
+++ b/postfix/startup.sh
@@ -20,10 +20,10 @@ chown root:root /etc/postfix/sasl_passwd /etc/postfix/sasl_passwd.lmdb
 chmod 600 /etc/postfix/sasl_passwd /etc/postfix/sasl_passwd.lmdb
 
 echo "Starting Atlassian IP updater in background"
-python3 /usr/local/bin/ip_updater.py > /var/log/ip_updater.log 2>&1 &
+python3 /usr/local/bin/ip_updater.py > /var/log/ip_updater/ip_updater.log 2>&1 &
 
 echo "Starting health check service in background"
-python3 /usr/local/bin/health_check.py > /var/log/health_check.log 2>&1 &
+python3 /usr/local/bin/health_check.py > /var/log/ip_updater/health_check.log 2>&1 &
 
 echo "Starting Postfix in foreground"
 postfix start-fg


### PR DESCRIPTION
Two small changes:
- adding the hostname to datadog metrics, so we can see hopefully the environment and machine
- moving the logs to a mounted folder, so it's easier to debug